### PR TITLE
v0.4

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app class="background">
-    <div v-if="$vuetify.breakpoint.mdAndDown" class="py-4 my-2">
+    <div v-if="$vuetify.breakpoint.mdAndDown" class="py-5 background">
       <v-app-bar dark color="primary" hide-on-scroll fixed>
         <v-fab-transition>
           <v-app-bar-nav-icon

--- a/src/components/Comments.vue
+++ b/src/components/Comments.vue
@@ -101,7 +101,7 @@ export default class Comments extends Vue {
   @Getter(Getters.SELECTED_PLAN) plan;
   /** @type {import("../../graphql/types").Comment[]} */
   comments = [];
-  isCreatingNewComment = false;
+  isCreatingNewComment = true;
   loader = false;
 
   @Prop(Array) privilegedUsers;

--- a/src/helpers/mutations.js
+++ b/src/helpers/mutations.js
@@ -89,6 +89,7 @@ export const createSubject = `mutation createSubject(
 
 export const updateMyMeeting = `mutation udpateMyMeeting(
   $id: ID!
+  $addedManually: Boolean
   $background: String
   $summary: String
   $committee: ID!
@@ -116,7 +117,7 @@ export const updateMyMeeting = `mutation udpateMyMeeting(
         transcript: $transcript
         additionalFiles: $additionalFiles
         plans: $plans
-        addedManually: true
+        addedManually: $addedManually
       }
     }
   ) {

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,6 +1,11 @@
 @import url("https://fonts.googleapis.com/css?family=Assistant:200,300,400,600,700,800&display=swap&subset=hebrew");
 $body-font-family: "Assistant", sans-serif;
 @import "~vuetify/src/styles/styles.sass";
+
+html {
+  scroll-behavior: smooth;
+}
+
 .font-weight-semibold {
   font-weight: 600 !important;
 }

--- a/src/plugins/store.js
+++ b/src/plugins/store.js
@@ -281,6 +281,9 @@ export default new Vuex.Store({
      */
     async [ActionTypes.FETCH_USER_SUBSCRIPTIONS](context) {
       const storeUser = context.getters[Getters.USER];
+      if (!storeUser) {
+        return;
+      }
       const result = await makeGqlRequest(
         getUserSubscriptions,
         { id: storeUser.id },

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -35,7 +35,7 @@
     </v-row>
     <v-row>
       <v-col>
-        <v-btn color="secondary" x-large :to="subscriptionDestination">
+        <v-btn color="secondary" x-large to="/subscriptions">
           <v-icon left>mdi-bell-plus</v-icon>
           צרו התראות חדשות
         </v-btn>
@@ -83,9 +83,6 @@ export default class Home extends Vue {
           managableMeeting => managableMeeting.id == meeting.id
         )
     }));
-  }
-  get subscriptionDestination() {
-    return this.user ? "/subscriptions" : "/login";
   }
 }
 </script>

--- a/src/views/ManageMeeting.vue
+++ b/src/views/ManageMeeting.vue
@@ -75,7 +75,7 @@
         </v-dialog>
       </v-col>
     </v-row>
-    <v-row v-if="addedManually">
+    <v-row>
       <v-col cols="12" md="8">
         <v-autocomplete
           label="קישור לתכניות"
@@ -93,7 +93,7 @@
           :search-input.sync="planSearch"
         ></v-autocomplete>
       </v-col>
-      <v-col cols="12" md="4">
+      <v-col cols="12" md="4" v-if="addedManually">
         <v-btn
           color="secondary"
           height="56px"
@@ -168,7 +168,7 @@
       :items="agendaItems"
       @cardRemove="handleAgendaItemRemoveClicked"
       @cardEdit="handleAgendaItemEditClicked"
-      :areCardsRemovable="addedManually"
+      areCardsRemovable
     ></AgendaCards>
     <v-row>
       <v-col cols="12" md="4">
@@ -538,6 +538,7 @@ export default class ManageMeeting extends Vue {
     const uploadedFiles = await this.uploadFiles();
     let meeting = {
       additionalFiles: uploadedFiles.additionalFiles,
+      addedManually: this.addedManually,
       background: this.background,
       committee: this.committee,
       date: this.meetingDateString,

--- a/src/views/ManageMeeting.vue
+++ b/src/views/ManageMeeting.vue
@@ -29,7 +29,6 @@
           label="מספר/כותרת ישיבה"
           hide-details
           outlined
-          :disabled="!addedManually"
         ></v-text-field>
       </v-col>
     </v-row>

--- a/src/views/Plan.vue
+++ b/src/views/Plan.vue
@@ -54,27 +54,39 @@
         </v-row>
       </v-col>
       <v-col>
-        <v-card flat class="pa-4">
-          <h4 class="title primary--text" tabindex="0">נתונים</h4>
-          <Map
-            class="my-3"
-            :query="planLocationQuery"
-            v-if="planLocationQuery"
-          />
-          <v-row
-            v-for="infoItem in planInformation"
-            :key="infoItem.key"
-            no-gutters
-            class="py-1"
-          >
-            <v-col cols="4" class="font-weight-semibold">
-              <span tabindex="0">{{ infoItem.key }}</span>
-            </v-col>
-            <v-col cols="7" offset="1">
-              <span tabindex="0">{{ infoItem.value }}</span>
-            </v-col>
-          </v-row>
-        </v-card>
+        <v-row no-gutters>
+          <v-col>
+            <v-btn color="secondary" block large href="#comments">
+              <v-icon left>mdi-plus</v-icon>
+              התייחסות חדשה
+            </v-btn>
+          </v-col>
+        </v-row>
+        <v-row>
+          <v-col>
+            <v-card flat class="pa-4">
+              <h4 class="title primary--text" tabindex="0">נתונים</h4>
+              <Map
+                class="my-3"
+                :query="planLocationQuery"
+                v-if="planLocationQuery"
+              />
+              <v-row
+                v-for="infoItem in planInformation"
+                :key="infoItem.key"
+                no-gutters
+                class="py-1"
+              >
+                <v-col cols="4" class="font-weight-semibold">
+                  <span tabindex="0">{{ infoItem.key }}</span>
+                </v-col>
+                <v-col cols="7" offset="1">
+                  <span tabindex="0">{{ infoItem.value }}</span>
+                </v-col>
+              </v-row>
+            </v-card>
+          </v-col>
+        </v-row>
       </v-col>
     </v-row>
     <v-row v-else>
@@ -102,7 +114,11 @@
       <v-col>
         <v-row justify="space-between" align="center">
           <v-col cols="auto">
-            <h4 class="title primary--text d-inline-block" tabindex="0">
+            <h4
+              class="title primary--text d-inline-block"
+              tabindex="0"
+              id="comments"
+            >
               התייחסויות
             </h4>
           </v-col>

--- a/src/views/Subscriptions.vue
+++ b/src/views/Subscriptions.vue
@@ -1,5 +1,20 @@
 <template>
   <v-container pa-md-12 pa-5>
+    <v-dialog v-model="showLoginDialog" persistent max-width="420px">
+      <v-card>
+        <v-card-title>
+          אינך מחובר/ת למערכת
+        </v-card-title>
+        <v-card-text>
+          על-מנת לצפות בהתראות ולהוסיף התראות חדשות, יש להתחבר למערכת
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn text @click="$router.go(-1)">ביטול</v-btn>
+          <v-btn text color="secondary" to="/login">קחו אותי להתחברות</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-row class="mb-5">
       <v-col>
         <h1 class="display-1 font-weight-black primary--text" tabindex="0">
@@ -161,6 +176,7 @@ export default class Subscriptions extends Vue {
   committeeSearch = "";
   subscribedCommittees = [];
   tab = null;
+  showLoginDialog = false;
   committeeHeaders = [
     { text: "שם ועדה", value: "sid" },
     { text: "מחוז", value: "area.sid" },
@@ -180,7 +196,9 @@ export default class Subscriptions extends Vue {
   }
 
   mounted() {
-    this.subscribedCommittees = this.user.subscribedCommittees;
+    this.subscribedCommittees =
+      (this.user && this.user.subscribedCommittees) || [];
+    this.showLoginDialog = !this.user;
   }
 
   subscribeToCommittee(committee) {

--- a/tests/unit/comments.spec.js
+++ b/tests/unit/comments.spec.js
@@ -280,9 +280,9 @@ describe("Comments.vue", () => {
     expect(newCommentButton.attributes("disabled")).toBeTruthy();
   });
   it("displays NewComment component when it should", () => {
-    expect(wrapper.find("NewComment-stub").exists()).toBeFalsy();
-    wrapper.vm.isCreatingNewComment = true;
     expect(wrapper.find("NewComment-stub").exists()).toBeTruthy();
+    wrapper.vm.isCreatingNewComment = false;
+    expect(wrapper.find("NewComment-stub").exists()).toBeFalsy();
   });
   it("generates correct root comments", () => {
     expect(wrapper.vm.rootComments).toHaveLength(

--- a/tests/unit/manage.meeting.spec.js
+++ b/tests/unit/manage.meeting.spec.js
@@ -113,10 +113,6 @@ describe("ManageMeeting.vue", () => {
     expect(
       wrapper.find('[label="מספר/כותרת ישיבה"]').props("disabled")
     ).toBeTruthy();
-    expect(wrapper.find('[label="קישור לתכניות"]').exists()).toBeFalsy();
     expect(wrapper.html()).not.toContain("הוספת נושא");
-    expect(
-      wrapper.find("AgendaCards-stub").props("areCardsRemovable")
-    ).toBeFalsy();
   });
 });

--- a/tests/unit/manage.meeting.spec.js
+++ b/tests/unit/manage.meeting.spec.js
@@ -98,9 +98,6 @@ describe("ManageMeeting.vue", () => {
   });
   it("disables some fields when a meeting isn't a manual one.", () => {
     expect(wrapper.find('[label="מוסד תכנוני"]').props("disabled")).toBeFalsy();
-    expect(
-      wrapper.find('[label="מספר/כותרת ישיבה"]').props("disabled")
-    ).toBeFalsy();
     expect(wrapper.find('[label="קישור לתכניות"]').exists()).toBeTruthy();
     expect(wrapper.html()).toContain("הוספת נושא");
     expect(
@@ -109,9 +106,6 @@ describe("ManageMeeting.vue", () => {
     wrapper.vm.addedManually = false;
     expect(
       wrapper.find('[label="מוסד תכנוני"]').props("disabled")
-    ).toBeTruthy();
-    expect(
-      wrapper.find('[label="מספר/כותרת ישיבה"]').props("disabled")
     ).toBeTruthy();
     expect(wrapper.html()).not.toContain("הוספת נושא");
   });

--- a/tests/unit/plan.spec.js
+++ b/tests/unit/plan.spec.js
@@ -228,10 +228,10 @@ describe("Plan.vue", () => {
     expect(wrapper.vm.planMeetings).toHaveLength(0);
   });
   it("loads plan status when it exists", () => {
-    expect(wrapper.find("v-icon-stub").exists()).toBeTruthy();
+    expect(wrapper.findAll("v-icon-stub")).toHaveLength(2);
     expect(wrapper.find("v-icon-stub").text()).toBe("mdi-update");
     plan.status = "";
-    expect(wrapper.find("v-icon-stub").exists()).toBeFalsy();
+    expect(wrapper.findAll("v-icon-stub")).toHaveLength(1);
   });
   it("loads plan number when it exists", () => {
     expect(wrapper.text()).toContain(plan.number);


### PR DESCRIPTION
# Features
- Subscription screen is visible for a public user
- Title, agenda of scraped meeting may be edited

# Enhancements
- `NewComment` is visible by default
- Added a button in plan view that takes the user to the comments section 

# Fixes
- Removed white stripe on small screens, beneath the app bar
- Route change is smoother
- Meetings were set to `addedManually` after edits